### PR TITLE
Fix typo: Mittagesssen → Mittagessen

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,7 +651,7 @@ footer { padding: 20px; flex-direction: column; }
     <div class="entry-right">
       <span class="entry-status status-done">Abgeschlossen</span>
       <h2>Schulsanierung Neureut: Turnhalle und Mensa wiedereröffnet</h2>
-      <p class="entry-body">Nach 14 Monaten Bauzeit wurde die sanierte Sporthalle und Mensa der Friedrich-Hecker-Schule in Neureut im Oktober 2025 wiedereröffnet. Kosten: 3,6 Mio. €. Die Mensa fasst jetzt 180 Schüler:innen gleichzeitig statt früher 80. Mittagesssen kann ab sofort online gebucht werden.</p>
+      <p class="entry-body">Nach 14 Monaten Bauzeit wurde die sanierte Sporthalle und Mensa der Friedrich-Hecker-Schule in Neureut im Oktober 2025 wiedereröffnet. Kosten: 3,6 Mio. €. Die Mensa fasst jetzt 180 Schüler:innen gleichzeitig statt früher 80. Mittagessen kann ab sofort online gebucht werden.</p>
       <p class="entry-source">Ortschaftsrat Neureut · Oktober 2025</p>
       <div class="entry-tags">
         <span class="entry-tag">Eltern / Schule</span>


### PR DESCRIPTION
## Summary

Fixes a typo in the Neureut school entry (Friedrich-Hecker-Schule): "Mittagesssen" → "Mittagessen".

## What was changed

`index.html`, line ~654: One extra "s" removed in the word "Mittagessen".

Generated with [Claude Code](https://claude.com/claude-code)